### PR TITLE
Adds methods to make webref and webfsim more useful as libraries

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyFSs7UnsU=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJu4ZbSc=

--- a/pkg/webfsim/filehandle.go
+++ b/pkg/webfsim/filehandle.go
@@ -1,0 +1,58 @@
+package webfsim
+
+import (
+	"context"
+	"io"
+	"time"
+
+	webref "github.com/brendoncarroll/webfs/pkg/webref"
+)
+
+type FileReader struct {
+	pos int64
+	f   *File
+	s   webref.Getter
+
+	readTimeout time.Duration
+}
+
+func NewFileReader(s webref.Getter, f *File) *FileReader {
+	return &FileReader{
+		pos: 0,
+		f:   f,
+		s:   s,
+	}
+}
+
+func (fr *FileReader) Read(p []byte) (n int, err error) {
+	var (
+		ctx = context.Background()
+		cf  context.CancelFunc
+	)
+	if fr.readTimeout > 0 {
+		ctx, cf = context.WithTimeout(context.Background(), fr.readTimeout)
+		defer cf()
+	}
+
+	n, err = FileReadAt(ctx, fr.s, *fr.f, uint64(fr.pos), p)
+	fr.pos += int64(n)
+	return n, err
+}
+
+func (fr *FileReader) Seek(off int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekCurrent:
+		fr.pos += off
+	case io.SeekStart:
+		fr.pos = off
+	case io.SeekEnd:
+		fr.pos = int64(fr.f.Size) - off
+	default:
+		panic("bad value for seek")
+	}
+	return fr.pos, nil
+}
+
+func (fr *FileReader) SetReadTimeout(t time.Duration) {
+	fr.readTimeout = t
+}

--- a/pkg/webref/codecs.go
+++ b/pkg/webref/codecs.go
@@ -139,3 +139,17 @@ func Decode(codec string, data []byte, x interface{}) error {
 	}
 	return nil
 }
+
+func (r *Ref) MarshalJSON() ([]byte, error) {
+	m := jsonpb.Marshaler{}
+	buf := &bytes.Buffer{}
+	if err := m.Marshal(buf, r); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (r *Ref) UnmarshalJSON(data []byte) error {
+	return jsonpb.Unmarshal(bytes.NewBuffer(data), r)
+}


### PR DESCRIPTION
webfsim.FileReader allows for convenient reading of webfsim.File.
webref.Ref now implements MarshalJSON and UnmarshalJSON so it (a
proto.Message) can be serialized by library users.